### PR TITLE
Fix application tools: dict→model coercion and SDK request-config for $filter

### DIFF
--- a/src/msgraph_mcp_server/resources/applications.py
+++ b/src/msgraph_mcp_server/resources/applications.py
@@ -7,9 +7,135 @@ import logging
 from typing import Dict, List, Any, Optional
 from utils.graph_client import GraphClient
 from msgraph.generated.models.application import Application
+from msgraph.generated.models.web_application import WebApplication
+from msgraph.generated.models.api_application import ApiApplication
+from msgraph.generated.models.public_client_application import PublicClientApplication
+from msgraph.generated.models.spa_application import SpaApplication
+from msgraph.generated.models.implicit_grant_settings import ImplicitGrantSettings
+from msgraph.generated.models.permission_scope import PermissionScope
+from msgraph.generated.models.required_resource_access import RequiredResourceAccess
+from msgraph.generated.models.resource_access import ResourceAccess
 from .service_principals import get_service_principal_by_app_id
 
 logger = logging.getLogger(__name__)
+
+
+def _build_web_application(data: Any) -> WebApplication:
+    """Coerce a dict (or pass through a model) into a WebApplication."""
+    if isinstance(data, WebApplication):
+        return data
+    web = WebApplication()
+    if 'redirectUris' in data:
+        web.redirect_uris = data['redirectUris']
+    if 'homePageUrl' in data:
+        web.home_page_url = data['homePageUrl']
+    if 'logoutUrl' in data:
+        web.logout_url = data['logoutUrl']
+    if 'implicitGrantSettings' in data and data['implicitGrantSettings'] is not None:
+        igs_data = data['implicitGrantSettings']
+        igs = ImplicitGrantSettings()
+        if 'enableAccessTokenIssuance' in igs_data:
+            igs.enable_access_token_issuance = igs_data['enableAccessTokenIssuance']
+        if 'enableIdTokenIssuance' in igs_data:
+            igs.enable_id_token_issuance = igs_data['enableIdTokenIssuance']
+        web.implicit_grant_settings = igs
+    return web
+
+
+def _build_redirect_uri_app(cls, data: Any):
+    """Coerce a dict into a PublicClientApplication or SpaApplication (redirectUris only)."""
+    if isinstance(data, cls):
+        return data
+    obj = cls()
+    if 'redirectUris' in data:
+        obj.redirect_uris = data['redirectUris']
+    return obj
+
+
+def _build_api_application(data: Any) -> ApiApplication:
+    """Coerce a dict (or pass through a model) into an ApiApplication."""
+    if isinstance(data, ApiApplication):
+        return data
+    api = ApiApplication()
+    if 'acceptMappedClaims' in data:
+        api.accept_mapped_claims = data['acceptMappedClaims']
+    if 'requestedAccessTokenVersion' in data:
+        api.requested_access_token_version = data['requestedAccessTokenVersion']
+    if 'knownClientApplications' in data:
+        api.known_client_applications = data['knownClientApplications']
+    if 'oauth2PermissionScopes' in data and data['oauth2PermissionScopes'] is not None:
+        scopes = []
+        for s in data['oauth2PermissionScopes']:
+            if isinstance(s, PermissionScope):
+                scopes.append(s)
+                continue
+            scope = PermissionScope()
+            scope.id = s.get('id')
+            scope.value = s.get('value')
+            scope.type = s.get('type')
+            scope.is_enabled = s.get('isEnabled')
+            scope.admin_consent_display_name = s.get('adminConsentDisplayName')
+            scope.admin_consent_description = s.get('adminConsentDescription')
+            scope.user_consent_display_name = s.get('userConsentDisplayName')
+            scope.user_consent_description = s.get('userConsentDescription')
+            scopes.append(scope)
+        api.oauth2_permission_scopes = scopes
+    return api
+
+
+def _build_required_resource_access(items: Any) -> List[RequiredResourceAccess]:
+    """Coerce a list of dicts into a list of RequiredResourceAccess models."""
+    result: List[RequiredResourceAccess] = []
+    for item in items or []:
+        if isinstance(item, RequiredResourceAccess):
+            result.append(item)
+            continue
+        rra = RequiredResourceAccess()
+        rra.resource_app_id = item.get('resourceAppId')
+        resource_access = []
+        for ra in item.get('resourceAccess', []) or []:
+            if isinstance(ra, ResourceAccess):
+                resource_access.append(ra)
+                continue
+            access = ResourceAccess()
+            access.id = ra.get('id')
+            access.type = ra.get('type')
+            resource_access.append(access)
+        rra.resource_access = resource_access
+        result.append(rra)
+    return result
+
+
+def _apply_app_data(app: Application, app_data: Dict[str, Any]) -> Application:
+    """Apply a plain-dict app payload onto an Application model, coercing nested
+    object/array fields into their typed Kiota models.
+
+    Assigning raw dicts to fields like ``app.web`` / ``app.api`` /
+    ``app.required_resource_access`` makes request serialization fail with
+    ``'dict' object has no attribute 'serialize'`` because the Graph SDK calls
+    ``.serialize()`` on each field. Coercing here avoids that.
+    """
+    if 'displayName' in app_data:
+        app.display_name = app_data['displayName']
+    if 'signInAudience' in app_data:
+        app.sign_in_audience = app_data['signInAudience']
+    if 'tags' in app_data:
+        app.tags = app_data['tags']
+    if 'identifierUris' in app_data:
+        app.identifier_uris = app_data['identifierUris']
+    if 'isFallbackPublicClient' in app_data:
+        app.is_fallback_public_client = app_data['isFallbackPublicClient']
+    if 'web' in app_data and app_data['web'] is not None:
+        app.web = _build_web_application(app_data['web'])
+    if 'api' in app_data and app_data['api'] is not None:
+        app.api = _build_api_application(app_data['api'])
+    if 'publicClient' in app_data and app_data['publicClient'] is not None:
+        app.public_client = _build_redirect_uri_app(PublicClientApplication, app_data['publicClient'])
+    if 'spa' in app_data and app_data['spa'] is not None:
+        app.spa = _build_redirect_uri_app(SpaApplication, app_data['spa'])
+    if 'requiredResourceAccess' in app_data and app_data['requiredResourceAccess'] is not None:
+        app.required_resource_access = _build_required_resource_access(app_data['requiredResourceAccess'])
+    return app
 
 async def list_applications(graph_client: GraphClient, limit: int = 100) -> List[Dict[str, Any]]:
     """List all applications (app registrations) in the tenant, with paging."""
@@ -121,22 +247,7 @@ async def create_application(graph_client: GraphClient, app_data: Dict[str, Any]
     """Create a new application (app registration)."""
     try:
         client = graph_client.get_client()
-        app = Application()
-        # Set properties from app_data
-        if 'displayName' in app_data:
-            app.display_name = app_data['displayName']
-        if 'signInAudience' in app_data:
-            app.sign_in_audience = app_data['signInAudience']
-        if 'tags' in app_data:
-            app.tags = app_data['tags']
-        if 'identifierUris' in app_data:
-            app.identifier_uris = app_data['identifierUris']
-        if 'web' in app_data:
-            app.web = app_data['web']
-        if 'api' in app_data:
-            app.api = app_data['api']
-        if 'requiredResourceAccess' in app_data:
-            app.required_resource_access = app_data['requiredResourceAccess']
+        app = _apply_app_data(Application(), app_data)
         new_app = await client.applications.post(app)
         if new_app:
             return {
@@ -157,22 +268,7 @@ async def update_application(graph_client: GraphClient, app_id: str, app_data: D
     """Update an existing application (app registration)."""
     try:
         client = graph_client.get_client()
-        app = Application()
-        # Set updatable properties from app_data
-        if 'displayName' in app_data:
-            app.display_name = app_data['displayName']
-        if 'signInAudience' in app_data:
-            app.sign_in_audience = app_data['signInAudience']
-        if 'tags' in app_data:
-            app.tags = app_data['tags']
-        if 'identifierUris' in app_data:
-            app.identifier_uris = app_data['identifierUris']
-        if 'web' in app_data:
-            app.web = app_data['web']
-        if 'api' in app_data:
-            app.api = app_data['api']
-        if 'requiredResourceAccess' in app_data:
-            app.required_resource_access = app_data['requiredResourceAccess']
+        app = _apply_app_data(Application(), app_data)
         await client.applications.by_application_id(app_id).patch(app)
         # Return the updated application
         return await get_application_by_id(graph_client, app_id)

--- a/src/msgraph_mcp_server/resources/service_principals.py
+++ b/src/msgraph_mcp_server/resources/service_principals.py
@@ -7,6 +7,8 @@ import logging
 from typing import Dict, List, Any, Optional
 from utils.graph_client import GraphClient
 from msgraph.generated.models.service_principal import ServicePrincipal
+from msgraph.generated.service_principals.service_principals_request_builder import ServicePrincipalsRequestBuilder
+from kiota_abstractions.base_request_configuration import RequestConfiguration
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +46,14 @@ async def get_service_principal_by_app_id(graph_client: GraphClient, app_id: str
     """Get a service principal by its appId (application client ID)."""
     try:
         client = graph_client.get_client()
-        # Filter by appId
-        filter_query = f"appId eq '{app_id}'"
-        response = await client.service_principals.get(query_parameters={"$filter": filter_query})
+        # Filter by appId. The SDK expects a typed query-parameters object wrapped
+        # in a RequestConfiguration, not a raw query_parameters kwarg (which raises
+        # "get() got an unexpected keyword argument 'query_parameters'").
+        query_params = ServicePrincipalsRequestBuilder.ServicePrincipalsRequestBuilderGetQueryParameters(
+            filter=f"appId eq '{app_id}'",
+        )
+        request_configuration = RequestConfiguration(query_parameters=query_params)
+        response = await client.service_principals.get(request_configuration=request_configuration)
         if response and response.value:
             return response.value[0]  # Return the first match
         return None


### PR DESCRIPTION
## Summary

Two application-management tools were broken against the current `msgraph` SDK (1.28.0). Both are fixed here with live-tenant verification.

### 1. `create_application` / `update_application` — `'dict' object has no attribute 'serialize'`

`create_application` and `update_application` assigned raw dicts directly to typed Kiota model fields:

```python
app.web = app_data['web']
app.api = app_data['api']
app.required_resource_access = app_data['requiredResourceAccess']
```

The Graph SDK serializes the request body by calling `.serialize()` on each field, so a plain `dict` raises `'dict' object has no attribute 'serialize'` on every create/update that includes `web`, `api`, or `requiredResourceAccess`.

**Fix:** coercion helpers that build the proper models (`WebApplication`, `ApiApplication`, `PublicClientApplication`, `SpaApplication`, `RequiredResourceAccess`/`ResourceAccess`, `PermissionScope`, `ImplicitGrantSettings`) and a shared `_apply_app_data()` used by both functions (removing the duplicated blocks). Also adds `publicClient`, `spa`, and `isFallbackPublicClient` support so delegated public-client app registrations can be created.

### 2. `get_application_by_id` — `get() got an unexpected keyword argument 'query_parameters'`

`get_application_by_id` calls `get_service_principal_by_app_id`, which did:

```python
await client.service_principals.get(query_parameters={"$filter": filter_query})
```

The SDK's `.get()` takes a `request_configuration` object, not a `query_parameters` kwarg, so this raised `ServicePrincipalsRequestBuilder.get() got an unexpected keyword argument 'query_parameters'` — breaking both `get_service_principal_by_app_id` and `get_application_by_id`.

**Fix:** build a typed `ServicePrincipalsRequestBuilderGetQueryParameters(filter=...)` wrapped in `RequestConfiguration`.

## Verification

- Reproduced the original serialize error with a raw-dict assignment; confirmed it's gone after coercion by serializing a realistic payload (Mail.Read delegated scope + public-client redirect + web/api) through the SDK's `JsonSerializationWriter`.
- Ran the fixed `get_application_by_id` against a live tenant for a real object ID — returns full data including `appRoleAssignments` / `oauth2PermissionGrants` (the `servicePrincipals?$filter=appId eq '...'` request now succeeds with 200).
- `py_compile` passes for both modules.

## Files

- `src/msgraph_mcp_server/resources/applications.py`
- `src/msgraph_mcp_server/resources/service_principals.py`